### PR TITLE
Escape windows shell parameters

### DIFF
--- a/wireshark_investigators_pack.lua
+++ b/wireshark_investigators_pack.lua
@@ -26,7 +26,7 @@ function win_escape_parameter(parameter)
         parameter = parameter:gsub(special_char, '^^^'.. special_char)
     end
     -- % is used for Windows shell variable expansion, it too must be escaped
-    parameter = parameter:gsub("%", "%%%%")
+    parameter = parameter:gsub("%%", "%%%%")
     return parameter
 end
 


### PR DESCRIPTION
Escape windows shell parameters to avoid command injection. Fixes #2.